### PR TITLE
Fix Backoff Strategy for 429 Too Many Requests (Rate limit error)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ with open("README.md", "r") as fh:
     long_description = fh.read()
 
 setup(name='pipelinewise-tap-mixpanel',
-      version='1.2.16',
+      version='1.2.17',
       description='Singer.io tap for extracting data from the mixpanel API - PipelineWise compatible',
       long_description=long_description,
       long_description_content_type='text/markdown',

--- a/tests/configuration/fixtures.py
+++ b/tests/configuration/fixtures.py
@@ -4,6 +4,6 @@ from tap_mixpanel.client import MixpanelClient
 
 @pytest.fixture
 def mixpanel_client():
-    mixpanel_client = MixpanelClient('API_SECRET')
+    mixpanel_client = MixpanelClient('API_SECRET', 'username', 'password', 'project_id')
     mixpanel_client._MixpanelClient__verified = True
     return mixpanel_client


### PR DESCRIPTION
## Problem

The error 429 (too many requests, rate limit error) was being ignored and re-raised the first time it was showing up. The exception custom class (that the backoff was expecting) was created but was never used since it was not included in the `ERROR_CODE_EXCEPTION_MAPPING` or manually raised.

## Proposed changes

So we included the exception in the backoff strategy to retry in case this exception is raised.

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)


## Checklist

- [ ] Description above provides context of the change
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] Unit tests for changes (not needed for documentation changes)
- [ ] CI checks pass with my changes
- [ ] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ ] Relevant documentation is updated including usage instructions