### PR TITLE
Request gzip-encoded export data

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -272,6 +272,10 @@ class MixpanelClient(object):
 
         kwargs['headers']['Accept'] = 'application/json'
 
+        # requests automatically decompresses gzip-encoded responses
+        # https://requests.readthedocs.io/en/latest/community/faq/#encoded-data
+        kwargs['headers']['Accept-Encoding'] = 'gzip'
+
         if self.__user_agent:
             kwargs['headers']['User-Agent'] = self.__user_agent
 


### PR DESCRIPTION
The export endpoint supports gzip-encoding with the `Accept-Encoding: gzip` header: https://developer.mixpanel.com/reference/raw-event-export

PR to improve performance for the `export` stream by adding this header, since `requests` [automatically decompresses gzip-encoded responses](https://requests.readthedocs.io/en/latest/community/faq/).