### PR TITLE
fix: Remove enforced start date limit

### DIFF
--- a/tap_mixpanel/__init__.py
+++ b/tap_mixpanel/__init__.py
@@ -36,14 +36,6 @@ def main():
     parsed_args = singer.utils.parse_args(REQUIRED_CONFIG_KEYS)
 
     start_date = parsed_args.config['start_date']
-    start_dttm = strptime_to_utc(start_date)
-    now_dttm = utils.now()
-    delta_days = (now_dttm - start_dttm).days
-    if delta_days >= 365:
-        delta_days = 365
-        start_date = strftime(now_dttm - timedelta(days=delta_days))
-        LOGGER.warning("WARNING: start_date greater than 1 year maxiumum for API.")
-        LOGGER.warning("WARNING: Setting start_date to 1 year ago, {}".format(start_date))
 
     #Initialize necessary keys into the dictionary.
     params = parsed_args.config

--- a/tap_mixpanel/sync.py
+++ b/tap_mixpanel/sync.py
@@ -180,10 +180,6 @@ def sync_endpoint(client, #pylint: disable=too-many-branches
             delta_days = attribution_window
             LOGGER.info("Start bookmark less than {} day attribution window.".format(
                 attribution_window))
-        elif delta_days >= 365:
-            delta_days = 365
-            LOGGER.warning("WARNING: Start date or bookmark greater than 1 year maxiumum.")
-            LOGGER.warning("WARNING: Setting bookmark start to 1 year ago.")
 
         start_window = now_datetime - timedelta(days=delta_days)
         end_window = start_window + timedelta(days=days_interval)


### PR DESCRIPTION
Current API has no such year limit on `from_date` param. The only limit I have observed is anything before `2011-07-10` specifically (`/export` endpoint):

```
from_date cannot be earlier than 2011-07-10
```