### PR TITLE
HGI-7974 - Support standard enum for server

### DIFF
--- a/tap_mixpanel/client.py
+++ b/tap_mixpanel/client.py
@@ -312,7 +312,7 @@ class MixpanelClient(object):
                 yield record
 
     def _with_server(self, url: str):
-        if not self.server:
+        if not self.server or self.server.strip().lower() == "standard":
             return url
 
         result = urllib.parse.urlsplit(url)


### PR DESCRIPTION
Supports using `server: "standard"` instead of null server in order to direct to standard residency server